### PR TITLE
Fix proftpd crash in getnameinfo()

### DIFF
--- a/mDNSPosix/nss_mdns.c
+++ b/mDNSPosix/nss_mdns.c
@@ -1695,14 +1695,14 @@ is_applicable_addr (
 //----------
 // Types and Constants
 
-const char * k_conf_file = PREFIX"/etc/nss_mdns.conf";
+static const char * k_conf_file = PREFIX"/etc/nss_mdns.conf";
 #define CONF_LINE_SIZE 1024
 
-const char k_comment_char = '#';
+static const char k_comment_char = '#';
 
-const char * k_keyword_domain = "domain";
+static const char * k_keyword_domain = "domain";
 
-const char * k_default_domains [] =
+static const char * k_default_domains [] =
 {
     "local",
     "254.169.in-addr.arpa",
@@ -1781,7 +1781,7 @@ contains_domain_suffix (const config_t * conf, const char * addr);
 static config_t * g_config = NULL;
 // Configuration info
 
-pthread_mutex_t g_config_mutex =
+static pthread_mutex_t g_config_mutex =
 #ifdef PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP
     PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP;
 #else


### PR DESCRIPTION
There was a name conflict between proftpd and nss_mdns: both had init_config()